### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An NSStatusItem hosted view that supports handling both left and right click act
 
 ## Usage Example
 <pre>
-#import "RHStatusItemView.h"
+# import "RHStatusItemView.h"
 
 @property (retain) IBOutlet NSMenu *statusMenu; //Created in MainMenu.nib 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
